### PR TITLE
Pole Rotate

### DIFF
--- a/marppy/marp.py
+++ b/marppy/marp.py
@@ -95,9 +95,6 @@ class Marp(Apex):
         tau = np.arcsin(np.sin(np.pi/2-lam1)/np.sin(np.pi/2-lam2)*np.sin(beta)) - np.pi
 
         return lam2*180./np.pi, phi2*180./np.pi, tau*180./np.pi
-        # self.lam0 = lam2*180./np.pi
-        # self.phi0 = phi2*180./np.pi
-        # self.tau0 = tau*180./np.pi
 
 
     def apex2marp(self, alat, alon):

--- a/marppy/marp.py
+++ b/marppy/marp.py
@@ -55,7 +55,7 @@ class Marp(Apex):
            Field: the 12th generation, Earth, Planets and Space, 67(1), 79,
            :doi:`10.1186/s40623-015-0228-9`.
     """
-    def __init__(self, date=None, refh=0, datafile=None, lam0=0., phi0=0., alt=300., coords='apex'):
+    def __init__(self, date=None, refh=0, datafile=None, lam0=0., phi0=0., tau0=0., null=None, alt=300., coords='apex'):
 
         super(Marp, self).__init__(date=date, refh=refh, datafile=None)
 
@@ -64,6 +64,29 @@ class Marp(Apex):
 
         self.lam0 = lam0
         self.phi0 = phi0
+        self.tau0 = tau0+180.
+        # tau = angle between original pole and new null
+
+        # self.null2pole(null)
+
+    def null2pole(self, null):
+        lam1 = null[0]*np.pi/180.
+        phi1 = null[1]*np.pi/180.
+        beta = null[2]*np.pi/180.
+
+        lam2 = np.arcsin(np.cos(lam1)*np.cos(beta))
+        phi2 = phi1 + np.arctan2(np.sin(beta)*np.cos(lam1), -np.sin(lam1)*np.sin(lam2))
+
+        # c = lam1
+        # a = lam2
+        # tau = np.arccos(np.cos(c)/np.sin(a))
+        # print(c*180./np.pi, a*180./np.pi, np.cos(c)/np.sin(a), tau*180./np.pi)
+        tau = np.arcsin(np.sin(np.pi/2-lam1)/np.sin(np.pi/2-lam2)*np.sin(beta)) - np.pi
+        print(np.sin(lam1), np.sin(lam2), np.sin(beta), tau*180/np.pi)
+
+        self.lam0 = lam2*180./np.pi
+        self.phi0 = phi2*180./np.pi
+        self.tau0 = tau*180./np.pi
 
 
     def apex2marp(self, alat, alon):
@@ -85,20 +108,42 @@ class Marp(Apex):
             MARP longitude
         """
 
-        lam = alat*np.pi/180.
-        phi = alon*np.pi/180.
+        lamA = alat*np.pi/180.
+        phiA = alon*np.pi/180.
         lam0 = self.lam0*np.pi/180.
         phi0 = self.phi0*np.pi/180.
+        tau0 = self.tau0*np.pi/180.
+        the0 = np.pi/2.-lam0
 
-        xr = np.cos(lam0)*np.cos(lam)*np.cos(phi-phi0) + np.sin(lam0)*np.sin(lam)
-        yr = np.cos(lam)*np.sin(phi-phi0)
-        zr = -np.sin(lam0)*np.cos(lam)*np.cos(phi-phi0) + np.cos(lam0)*np.sin(lam)
+        # xr = np.cos(lam0)*np.cos(lam)*np.cos(phi-phi0) + np.sin(lam0)*np.sin(lam)
+        # yr = np.cos(lam)*np.sin(phi-phi0)
+        # zr = -np.sin(lam0)*np.cos(lam)*np.cos(phi-phi0) + np.cos(lam0)*np.sin(lam)
 
-        phir = np.arctan2(yr, xr)
-        lamr = np.arcsin(zr)
+        xA = np.cos(lamA)*np.cos(phiA)
+        yA = np.cos(lamA)*np.sin(phiA)
+        zA = np.sin(lamA)
+        rA = np.array([xA, yA, zA]).T
 
-        mlat = lamr*180./np.pi
-        mlon = phir*180./np.pi
+        Rtau = np.array([[np.cos(tau0), np.sin(tau0), 0.], [-np.sin(tau0), np.cos(tau0), 0.], [0., 0., 1.]])
+        # Rthe = np.array([[np.cos(the0), 0., np.sin(the0)], [0., 1., 0.], [-np.sin(the0), 0., np.cos(the0)]])
+        Rlam = np.array([[np.sin(lam0), 0., -np.cos(lam0)], [0., 1., 0.], [np.cos(lam0), 0., np.sin(lam0)]])
+        Rphi = np.array([[np.cos(phi0), np.sin(phi0), 0.], [-np.sin(phi0), np.cos(phi0), 0.], [0., 0., 1.]])
+        # print(rr)
+        R = np.einsum('ij,jk,kl->il', Rtau, Rlam, Rphi)
+
+        # r = np.einsum('ij,jk,kl,...l->...i', Rphi, Rthe, Rtau, rr).T
+        # r = np.einsum('ij,jk,kl,...l->...i', Rphi, Rthe, Rtau, rr).T
+        rM = np.einsum('ij,...j->...i', R, rA).T
+
+        xM = rM[0]
+        yM = rM[1]
+        zM = rM[2]
+
+        phiM = np.arctan2(yM, xM)
+        lamM = np.arcsin(zM)
+
+        mlat = lamM*180./np.pi
+        mlon = phiM*180./np.pi
 
         return mlat, mlon
 
@@ -121,20 +166,45 @@ class Marp(Apex):
             Apex longitude
         """
 
-        lamr = mlat*np.pi/180.
-        phir = mlon*np.pi/180.
+        lamM = mlat*np.pi/180.
+        phiM = mlon*np.pi/180.
         lam0 = self.lam0*np.pi/180.
         phi0 = self.phi0*np.pi/180.
+        tau0 = self.tau0*np.pi/180.
+        # the0 = np.pi/2.-lam0
 
-        x = np.cos(phi0)*np.cos(lam0)*np.cos(lamr)*np.cos(phir) - np.cos(phi0)*np.sin(lam0)*np.sin(lamr) - np.sin(phi0)*np.cos(lamr)*np.sin(phir)
-        y = np.sin(phi0)*np.cos(lam0)*np.cos(lamr)*np.cos(phir) - np.sin(phi0)*np.sin(lam0)*np.sin(lamr) + np.cos(phi0)*np.cos(lamr)*np.sin(phir)
-        z = np.sin(lam0)*np.cos(lamr)*np.cos(phir) + np.cos(lam0)*np.sin(lamr)
+        # x = np.cos(phi0)*np.cos(lam0)*np.cos(lamr)*np.cos(phir) - np.cos(phi0)*np.sin(lam0)*np.sin(lamr) - np.sin(phi0)*np.cos(lamr)*np.sin(phir)
+        # y = np.sin(phi0)*np.cos(lam0)*np.cos(lamr)*np.cos(phir) - np.sin(phi0)*np.sin(lam0)*np.sin(lamr) + np.cos(phi0)*np.cos(lamr)*np.sin(phir)
+        # z = np.sin(lam0)*np.cos(lamr)*np.cos(phir) + np.cos(lam0)*np.sin(lamr)
 
-        phi = np.arctan2(y, x)
-        lam = np.arcsin(z)
+        xM = np.cos(lamM)*np.cos(phiM)
+        yM = np.cos(lamM)*np.sin(phiM)
+        zM = np.sin(lamM)
+        rM = np.array([xM, yM, zM]).T
 
-        alat = lam*180./np.pi
-        alon = phi*180./np.pi
+        Rtau = np.array([[np.cos(tau0), -np.sin(tau0), 0.], [np.sin(tau0), np.cos(tau0), 0.], [0., 0., 1.]])
+        # Rthe = np.array([[np.cos(the0), 0., np.sin(the0)], [0., 1., 0.], [-np.sin(the0), 0., np.cos(the0)]])
+        Rlam = np.array([[np.sin(lam0), 0., np.cos(lam0)], [0., 1., 0.], [-np.cos(lam0), 0., np.sin(lam0)]])
+        Rphi = np.array([[np.cos(phi0), -np.sin(phi0), 0.], [np.sin(phi0), np.cos(phi0), 0.], [0., 0., 1.]])
+        # print(rr)
+        R = np.einsum('ij,jk,kl->il', Rphi, Rlam, Rtau)
+
+        # r = np.einsum('ij,jk,kl,...l->...i', Rphi, Rthe, Rtau, rr).T
+        # r = np.einsum('ij,jk,kl,...l->...i', Rphi, Rthe, Rtau, rr).T
+        rA = np.einsum('ij,...j->...i', R, rM).T
+
+        xA = rA[0]
+        yA = rA[1]
+        zA = rA[2]
+
+        # x = (np.cos(tau0)*np.sin(lam0)*np.cos(phi0)-np.sin(tau0)*np.sin(phi0))*xr + (np.cos(tau0)*np.sin(lam0)*np.sin(phi0)+np.sin(tau0)*np.cos(phi0))*yr - np.cos(tau0)*np.cos(lam0)
+
+
+        phiA = np.arctan2(yA, xA)
+        lamA = np.arcsin(zA)
+
+        alat = lamA*180./np.pi
+        alon = phiA*180./np.pi
 
         return alat, alon
 

--- a/marppy/marp.py
+++ b/marppy/marp.py
@@ -72,7 +72,8 @@ class Marp(Apex):
             if coords == 'geo':
                 f1, f2, f3, g1, g2, g3, d1, d2, d3, e1, e2, e3 = self.basevectors_apex(null[0], null[1], alt)
                 null[0], null[1] = self.geo2apex(null[0], null[1], alt)
-                null[2] = np.arccos(-(np.sin(null[2]*np.pi/180.)*e2[0] + np.cos(null[2]*np.pi/180.)*e2[1])/np.linalg.norm(e2))*180./np.pi
+                brg = np.array([np.sin(null[2]*np.pi/180.), np.cos(null[2]*np.pi/180.)])
+                null[2] = np.sign(np.cross(brg, -e2[:2]))*np.arccos(np.dot(brg, -e2[:2])/np.linalg.norm(e2[:2]))*180./np.pi
             lam0, phi0, tau0 = self.null2pole(null)
 
 
@@ -84,6 +85,7 @@ class Marp(Apex):
         # self.null2pole(null)
 
     def null2pole(self, null):
+        print(null)
         lam1 = null[0]*np.pi/180.
         phi1 = null[1]*np.pi/180.
         beta = null[2]*np.pi/180.
@@ -93,6 +95,7 @@ class Marp(Apex):
 
         # Use spherical law of cosines for this
         tau = np.arcsin(np.sin(np.pi/2-lam1)/np.sin(np.pi/2-lam2)*np.sin(beta)) - np.pi
+        # tau = -np.pi/2
 
         return lam2*180./np.pi, phi2*180./np.pi, tau*180./np.pi
 

--- a/misc_scripts/derivative_check.py
+++ b/misc_scripts/derivative_check.py
@@ -4,30 +4,116 @@
 #   the expressions copied from marp.py.
 # If all expressions are correct, all fields of the results printed to screen will be zero.
 
-from sympy import *
+# from sympy import *
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
 
 def contravariant_derivatives():
 
-    x, y, z, zr, yr, zr, l, p, lr, pr, l0, p0 = symbols('x y z xr yr zr l p lr pr l0 p0')
+    # x, y, z, zr, yr, zr, l, p, lr, pr, l0, p0 = symbols('x y z xr yr zr l p lr pr l0 p0')
+    #
+    # xr = cos(l0)*cos(l)*cos(p-p0) + sin(l0)*sin(l)
+    # yr = cos(l)*sin(p-p0)
+    # zr = -sin(l0)*cos(l)*cos(p-p0) + cos(l0)*sin(l)
+    #
+    # pr = atan2(yr,xr)
+    # lr = asin(zr)
+    #
+    # # partial derivatives hard-coded in marp.py
+    # dprdp = cos(l)*(cos(l0)*cos(l)+sin(l0)*sin(l)*cos(p-p0))/(xr**2+yr**2)
+    # dprdl = -sin(l0)*sin(p-p0)/(xr**2+yr**2)
+    # dlrdp = sin(l0)*cos(l)*sin(p-p0)/sqrt(1-zr**2)
+    # dlrdl = (sin(l0)*sin(l)*cos(p-p0)+cos(l0)*cos(l))/sqrt(1-zr**2)
+    #
+    # print('CONTRAVARIANT DERIVATIVES:')
+    # print('dprdp:', simplify(diff(pr, p)-dprdp))
+    # print('dprdl:', simplify(diff(pr, l)-dprdl))
+    # print('dlrdp:', simplify(diff(lr, p)-dlrdp))
+    # print('dlrdl:', simplify(diff(lr, l)-dlrdl))
 
-    xr = cos(l0)*cos(l)*cos(p-p0) + sin(l0)*sin(l)
-    yr = cos(l)*sin(p-p0)
-    zr = -sin(l0)*cos(l)*cos(p-p0) + cos(l0)*sin(l)
 
-    pr = atan2(yr,xr)
-    lr = asin(zr)
+    # Plot derivitative caluculated analytically and numerically to check correctness of analytic solution
+    
+    lam0 = 60.*np.pi/180.
+    phi0 = 30.*np.pi/180.
+    tau0 = 20.*np.pi/180.
 
-    # partial derivatives hard-coded in marp.py
-    dprdp = cos(l)*(cos(l0)*cos(l)+sin(l0)*sin(l)*cos(p-p0))/(xr**2+yr**2)
-    dprdl = -sin(l0)*sin(p-p0)/(xr**2+yr**2)
-    dlrdp = sin(l0)*cos(l)*sin(p-p0)/sqrt(1-zr**2)
-    dlrdl = (sin(l0)*sin(l)*cos(p-p0)+cos(l0)*cos(l))/sqrt(1-zr**2)
+    pA, lA = np.meshgrid(np.arange(0., 360., 0.5)*np.pi/180., np.arange(-90., 90., 0.5)*np.pi/180.)
 
-    print('CONTRAVARIANT DERIVATIVES:')
-    print('dprdp:', simplify(diff(pr, p)-dprdp))
-    print('dprdl:', simplify(diff(pr, l)-dprdl))
-    print('dlrdp:', simplify(diff(lr, p)-dlrdp))
-    print('dlrdl:', simplify(diff(lr, l)-dlrdl))
+    xA = np.cos(lA)*np.cos(pA)
+    yA = np.cos(lA)*np.sin(pA)
+    zA = np.sin(lA)
+    rA = np.array([xA, yA, zA]).T
+
+    Rtau = np.array([[np.cos(tau0), np.sin(tau0), 0.], [-np.sin(tau0), np.cos(tau0), 0.], [0., 0., 1.]])
+    Rlam = np.array([[np.sin(lam0), 0., -np.cos(lam0)], [0., 1., 0.], [np.cos(lam0), 0., np.sin(lam0)]])
+    Rphi = np.array([[np.cos(phi0), np.sin(phi0), 0.], [-np.sin(phi0), np.cos(phi0), 0.], [0., 0., 1.]])
+    # print(rr)
+    R = np.einsum('ij,jk,kl->il', Rtau, Rlam, Rphi)
+
+    rM = np.einsum('ij,...j->...i', R, rA).T
+
+    xM = rM[0]
+    yM = rM[1]
+    zM = rM[2]
+
+    pM = np.arctan2(yM, xM)
+    lM = np.arcsin(zM)
+
+
+    P1 = np.array([[-np.sin(pA)*np.cos(lA), -np.cos(pA)*np.sin(lA)], [np.cos(pA)*np.cos(lA), -np.sin(pA)*np.sin(lA)], [np.zeros(lA.shape), np.cos(lA)]])
+    P2 = np.array([[-yM/(xM**2+yM**2), xM/(xM**2+yM**2), np.zeros(xM.shape)], [np.zeros(xM.shape), np.zeros(xM.shape), 1./np.sqrt(1-zM**2)]])
+    dMdA = np.einsum('ij...,jk,kl...->il...', P2, R, P1)
+
+    print(pA.shape, lA.shape, dMdA.shape)
+
+    dpMdpA = dMdA[0,0]
+    dpMdlA = dMdA[0,1]
+    dlMdpA = dMdA[1,0]
+    dlMdlA = dMdA[1,1]
+
+    num_dpMdlA, num_dpMdpA = np.gradient(pM, lA[:,0], pA[0,:])
+    num_dlMdlA, num_dlMdpA = np.gradient(lM, lA[:,0], pA[0,:])
+    print(num_dpMdpA.shape)
+    # plt.plot(pA, lM)
+    # plt.plot(pA, np.gradient(lM, pA))
+    # plt.plot(pA, dlMdpA, linestyle=':')
+    fig = plt.figure(figsize=(10,10))
+    gs = gridspec.GridSpec(4,3)
+
+    ax = fig.add_subplot(gs[0,0])
+    ax.pcolormesh(pA, lA, dpMdpA, vmin=-np.pi, vmax=np.pi)
+    ax = fig.add_subplot(gs[0,1])
+    ax.pcolormesh(pA, lA, num_dpMdpA, vmin=-np.pi, vmax=np.pi)
+    ax = fig.add_subplot(gs[0,2])
+    ax.pcolormesh(pA, lA, dpMdpA-num_dpMdpA, vmin=-1e-2, vmax=1e-2)
+
+    ax = fig.add_subplot(gs[1,0])
+    ax.pcolormesh(pA, lA, dpMdlA, vmin=-np.pi, vmax=np.pi)
+    ax = fig.add_subplot(gs[1,1])
+    ax.pcolormesh(pA, lA, num_dpMdlA, vmin=-np.pi, vmax=np.pi)
+    ax = fig.add_subplot(gs[1,2])
+    ax.pcolormesh(pA, lA, dpMdlA-num_dpMdlA, vmin=-1e-2, vmax=1e-2)
+
+    ax = fig.add_subplot(gs[2,0])
+    ax.pcolormesh(pA, lA, dlMdpA, vmin=-np.pi, vmax=np.pi)
+    ax = fig.add_subplot(gs[2,1])
+    ax.pcolormesh(pA, lA, num_dlMdpA, vmin=-np.pi, vmax=np.pi)
+    ax = fig.add_subplot(gs[2,2])
+    ax.pcolormesh(pA, lA, dlMdpA-num_dlMdpA, vmin=-1e-2, vmax=1e-2)
+
+    ax = fig.add_subplot(gs[3,0])
+    ax.pcolormesh(pA, lA, dlMdlA, vmin=-np.pi, vmax=np.pi)
+    ax = fig.add_subplot(gs[3,1])
+    ax.pcolormesh(pA, lA, num_dlMdlA, vmin=-np.pi, vmax=np.pi)
+    ax = fig.add_subplot(gs[3,2])
+    ax.pcolormesh(pA, lA, dlMdlA-num_dlMdlA, vmin=-1e-2, vmax=1e-2)
+
+    plt.show()
+
+
+
 
 def covariant_derivatives():
 
@@ -54,7 +140,7 @@ def covariant_derivatives():
 
 def main():
     contravariant_derivatives()
-    covariant_derivatives()
+    # covariant_derivatives()
 
 if __name__=='__main__':
     main()

--- a/test_marppy.py
+++ b/test_marppy.py
@@ -8,7 +8,7 @@ from apexpy import Apex
 
 def test_apex2marp_norotation():
     # validate that if no rotation is set (lam0=0 & phi0=0), marp coordinates equal apex coordinates
-    marp = Marp(date=2019, lam0=90., phi0=0., tau0=180.)
+    marp = Marp(date=2019, pole=[90.,0.,0.])
     # alat, alon = np.meshgrid(np.arange(-90., 91., 1.), np.arange(-178., 182., 2.))
     alat, alon = np.meshgrid(np.arange(-89., 90., 1.), np.arange(-178., 180., 2.))
 
@@ -20,7 +20,7 @@ def test_apex2marp_norotation():
 
 def test_marp2apex_norotation():
     # validate that if no rotation is set (lam0=0 & phi0=0), apex coordinates equal marp coordinates
-    marp = Marp(date=2019, lam0=90., phi0=0., tau0=180.)
+    marp = Marp(date=2019, pole=[90.,0.,0.])
     # mlat, mlon = np.meshgrid(np.arange(-90., 91., 1.), np.arange(-178., 182., 2.))
     mlat, mlon = np.meshgrid(np.arange(-89., 90., 1.), np.arange(-178., 180., 2.))
 
@@ -30,27 +30,27 @@ def test_marp2apex_norotation():
     np.testing.assert_array_almost_equal(alon, mlon)
 
 
-# def test_apex2marp_center():
-#     # validate that the center point becomes (0,0) in marp
-#     marp = Marp(date=2019, lam0=60., phi0=30.)
-#     mlat, mlon = marp.apex2marp(60., 30.)
-#
-#     np.testing.assert_almost_equal(mlat, 0.)
-#     np.testing.assert_almost_equal(mlon, 0.)
-#
-#
-# def test_marp2apex_center():
-#     # validate that marp (0,0) becomes the center point in apex
-#     marp = Marp(date=2019, lam0=60., phi0=30.)
-#     alat, alon = marp.marp2apex(0., 0.)
-#
-#     np.testing.assert_almost_equal(alat, 60.)
-#     np.testing.assert_almost_equal(alon, 30.)
+def test_apex2marp_center():
+    # validate that the center point becomes (0,0) in marp
+    marp = Marp(date=2019, null=[60.,30.,10.])
+    mlat, mlon = marp.apex2marp(60., 30.)
+
+    np.testing.assert_almost_equal(mlat, 0.)
+    np.testing.assert_almost_equal(mlon, 0.)
+
+
+def test_marp2apex_center():
+    # validate that marp (0,0) becomes the center point in apex
+    marp = Marp(date=2019, null=[60.,30.,10.])
+    alat, alon = marp.marp2apex(0., 0.)
+
+    np.testing.assert_almost_equal(alat, 60.)
+    np.testing.assert_almost_equal(alon, 30.)
 
 
 def test_apex2marp():
     # validate that trasforming from apex to marp and back to apex returns the original coordinates
-    marp = Marp(date=2019, lam0=60., phi0=30.)
+    marp = Marp(date=2019, pole=[60.,30.,10.])
 
     alat0, alon0 = np.meshgrid(np.arange(-89., 90., 1.), np.arange(-178., 180., 2.))
 
@@ -63,7 +63,8 @@ def test_apex2marp():
 
 def test_marp2apex():
     # validate that trasforming from marp to apex and back to marp returns the original coordinates
-    marp = Marp(date=2019, lam0=60., phi0=30.)
+    # marp = Marp(date=2019, lam0=60., phi0=30.)
+    marp = Marp(date=2019, pole=[60.,30.,10.])
 
     mlat0, mlon0 = np.meshgrid(np.arange(-89., 90., 1.), np.arange(-178., 180., 2.))
 
@@ -76,7 +77,7 @@ def test_marp2apex():
 
 def test_geo2marp():
     # validate that tranforming from geodetic to marp and back to geodetic returns the original coordinates
-    marp = Marp(date=2019, lam0=60., phi0=30.)
+    marp = Marp(date=2019, pole=[60.,30.,10.])
 
     glat0, glon0 = np.meshgrid(np.arange(-89., 90., 1.), np.arange(-178., 180., 2.))
 
@@ -89,7 +90,7 @@ def test_geo2marp():
 
 def test_marp2geo():
     # validate that transforming from marp to geodetic and back to marp returns the original coordinates
-    marp = Marp(date=2019, lam0=60., phi0=30.)
+    marp = Marp(date=2019, pole=[60.,30.,10.])
 
     mlat0, mlon0 = np.meshgrid(np.arange(-89., 90., 1.), np.arange(-178., 180., 2.))
 
@@ -103,7 +104,7 @@ def test_marp2geo():
 def test_basevectors_norotation():
     # validate that if no rotation is set (lam0=0 & phi0=0), marp base vectors equal apex base vectors
     apex = Apex(date=2019)
-    marp = Marp(date=2019, lam0=90., phi0=0., tau0=180.)
+    marp = Marp(date=2019, pole=[90.,0.,0.])
 
     # glat, glon = np.meshgrid(np.arange(-89., 90., 2.), np.arange(-179., 180., 4.))
     glat, glon = np.meshgrid(np.arange(-90., 91., 1.), np.arange(-180., 181., 2.))
@@ -121,7 +122,7 @@ def test_basevectors_norotation():
 
 def test_basevectors_reciprocal():
     # validate that the basevectors are reciprocal, i.e. di*ej=delta{ij} (Richmond 1995, eqn 3.18)
-    marp = Marp(date=2019, lam0=60., phi0=30.)
+    marp = Marp(date=2019, pole=[60.,30.,10.])
     glat, glon = np.meshgrid(np.arange(-90., 91., 1.), np.arange(-180., 181., 2.))
 
     d1, d2, d3, e1, e2, e3 = marp.basevectors_marp(glat.flatten(), glon.flatten(), 0.)
@@ -156,7 +157,7 @@ def test_basevectors_reciprocal():
 def test_basevectors_scaled():
     # validate that the base vectors are properly scaled such that d1xd2*d3 = e1xe2*e3 = 1 (Richmond 1995, eqn 3.17)
     # this is a special property of Apex base vectors
-    marp = Marp(date=2019, lam0=60., phi0=30.)
+    marp = Marp(date=2019, pole=[60.,30.,10.])
     # glat, glon = np.meshgrid(np.arange(50., 90., 2.), np.arange(-179., 180., 4.))
     glat, glon = np.meshgrid(np.arange(-90., 91., 1.), np.arange(-180., 181., 2.))
 
@@ -168,7 +169,7 @@ def test_basevectors_scaled():
 
 def test_basevectors_parallel2B():
     # validate that d3 and e3 are parallel
-    marp = Marp(date=2019, lam0=60., phi0=30.)
+    marp = Marp(date=2019, pole=[60.,30.,10.])
     glat, glon = np.meshgrid(np.arange(-90., 91., 1.), np.arange(-180., 181., 2.))
 
     d1, d2, d3, e1, e2, e3 = marp.basevectors_marp(glat.flatten(), glon.flatten(), 0.)
@@ -182,7 +183,7 @@ def test_basevectors_parallel2B():
 def test_basevectors_construction():
     # validate that the relationships between d and e shown in Richmond 1995, eqn 3.16
     #   and Laundal and Richmond 2016, eqn 57-59 hold true
-    marp = Marp(date=2019, lam0=60., phi0=30.)
+    marp = Marp(date=2019, pole=[60.,30.,10.])
     glat, glon = np.meshgrid(np.arange(-90., 91., 1.), np.arange(-180., 181., 2.))
 
     d1, d2, d3, e1, e2, e3 = marp.basevectors_marp(glat.flatten(), glon.flatten(), 0.)
@@ -199,7 +200,7 @@ def test_basevectors_construction():
 def test_mapping():
     # validate that for an Electric field mapped to different altitudes, Ed1 and Ed2 are constant and
     #   for a Velocity field maped to different altitudes, Ve1 and Ve2 are constant
-    marp = Marp(date=2019, lam0=60., phi0=30.)
+    marp = Marp(date=2019, pole=[60.,30.,10.])
 
     alat = 70.
     alon = 60.

--- a/test_marppy.py
+++ b/test_marppy.py
@@ -8,8 +8,9 @@ from apexpy import Apex
 
 def test_apex2marp_norotation():
     # validate that if no rotation is set (lam0=0 & phi0=0), marp coordinates equal apex coordinates
-    marp = Marp(date=2019, lam0=0., phi0=0.)
-    alat, alon = np.meshgrid(np.arange(-90., 91., 1.), np.arange(-178., 182., 2.))
+    marp = Marp(date=2019, lam0=90., phi0=0., tau0=180.)
+    # alat, alon = np.meshgrid(np.arange(-90., 91., 1.), np.arange(-178., 182., 2.))
+    alat, alon = np.meshgrid(np.arange(-89., 90., 1.), np.arange(-178., 180., 2.))
 
     mlat, mlon = marp.apex2marp(alat, alon)
 
@@ -19,8 +20,9 @@ def test_apex2marp_norotation():
 
 def test_marp2apex_norotation():
     # validate that if no rotation is set (lam0=0 & phi0=0), apex coordinates equal marp coordinates
-    marp = Marp(date=2019, lam0=0., phi0=0.)
-    mlat, mlon = np.meshgrid(np.arange(-90., 91., 1.), np.arange(-178., 182., 2.))
+    marp = Marp(date=2019, lam0=90., phi0=0., tau0=180.)
+    # mlat, mlon = np.meshgrid(np.arange(-90., 91., 1.), np.arange(-178., 182., 2.))
+    mlat, mlon = np.meshgrid(np.arange(-89., 90., 1.), np.arange(-178., 180., 2.))
 
     alat, alon = marp.apex2marp(mlat, mlon)
 
@@ -28,22 +30,22 @@ def test_marp2apex_norotation():
     np.testing.assert_array_almost_equal(alon, mlon)
 
 
-def test_apex2marp_center():
-    # validate that the center point becomes (0,0) in marp
-    marp = Marp(date=2019, lam0=60., phi0=30.)
-    mlat, mlon = marp.apex2marp(60., 30.)
-
-    np.testing.assert_almost_equal(mlat, 0.)
-    np.testing.assert_almost_equal(mlon, 0.)
-
-
-def test_marp2apex_center():
-    # validate that marp (0,0) becomes the center point in apex
-    marp = Marp(date=2019, lam0=60., phi0=30.)
-    alat, alon = marp.marp2apex(0., 0.)
-
-    np.testing.assert_almost_equal(alat, 60.)
-    np.testing.assert_almost_equal(alon, 30.)
+# def test_apex2marp_center():
+#     # validate that the center point becomes (0,0) in marp
+#     marp = Marp(date=2019, lam0=60., phi0=30.)
+#     mlat, mlon = marp.apex2marp(60., 30.)
+#
+#     np.testing.assert_almost_equal(mlat, 0.)
+#     np.testing.assert_almost_equal(mlon, 0.)
+#
+#
+# def test_marp2apex_center():
+#     # validate that marp (0,0) becomes the center point in apex
+#     marp = Marp(date=2019, lam0=60., phi0=30.)
+#     alat, alon = marp.marp2apex(0., 0.)
+#
+#     np.testing.assert_almost_equal(alat, 60.)
+#     np.testing.assert_almost_equal(alon, 30.)
 
 
 def test_apex2marp():
@@ -101,7 +103,7 @@ def test_marp2geo():
 def test_basevectors_norotation():
     # validate that if no rotation is set (lam0=0 & phi0=0), marp base vectors equal apex base vectors
     apex = Apex(date=2019)
-    marp = Marp(date=2019, lam0=0., phi0=0.)
+    marp = Marp(date=2019, lam0=90., phi0=0., tau0=180.)
 
     # glat, glon = np.meshgrid(np.arange(-89., 90., 2.), np.arange(-179., 180., 4.))
     glat, glon = np.meshgrid(np.arange(-90., 91., 1.), np.arange(-180., 181., 2.))


### PR DESCRIPTION
Modify code so that rotation can be specified by new location of [null island](https://en.wikipedia.org/wiki/Null_Island) or the new location of the north pole.  Furthermore, this version specifies the direction of magnetic north in the rotated coordinate system explicitly, adding a third axis of rotation.  When specifying the pole, this is equivalent to adding a final rotation once the pole is in the correct location so the prime meridian can lie in a specific direction.